### PR TITLE
⚙️ GitHub Pages

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,44 @@
+name: GH Pages Deploy
+
+on:
+  push:
+    branches: [main]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🛎
+        uses: actions/checkout@v4
+
+      - name: Install marmite 🫙
+        run: cargo install marmite
+
+      - name: Build site 🏗️
+        run: marmite . site --debug
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "site"
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow for deploying the site to GitHub Pages. The workflow automates the build and deployment process whenever there is a push to the `main` branch or when manually triggered.

**GitHub Pages Deployment Automation:**

* Added `.github/workflows/main.yaml` to automate building and deploying the site to GitHub Pages using GitHub Actions, including steps for checking out the code, installing dependencies, building the site, and deploying.
* Configured workflow triggers for pushes to the `main` branch and manual dispatch, and set appropriate permissions for deployment.