### PR TITLE
🔧 Atualizando .yaml para usar Python

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,11 +25,16 @@ jobs:
       - name: Checkout 🛎
         uses: actions/checkout@v4
 
-      - name: Install marmite 🫙
-        run: cargo install marmite
+      - name: Install uv
+        run: |
+          pip install uv
+
+      - name: Install dependencies
+        run: |
+          uv sync --no-dev
 
       - name: Build site 🏗️
-        run: marmite . site --debug
+        run: uv run marmite . site --debug
 
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
This pull request updates the workflow in `.github/workflows/main.yaml` to use `uv` for dependency management and running build commands, replacing the previous usage of `marmite` directly. The changes streamline dependency installation and site building steps.

Dependency management and build process updates:

* Replaced installation of `marmite` via `cargo` with installation of `uv` using `pip`. (`[.github/workflows/main.yamlL28-R37](diffhunk://#diff-71cabc4177e41ea8f15a89eb65398fa8187739f68a2762706d84885cd8b2ddc3L28-R37)`)
* Added a new step to install dependencies using `uv sync --no-dev`. (`[.github/workflows/main.yamlL28-R37](diffhunk://#diff-71cabc4177e41ea8f15a89eb65398fa8187739f68a2762706d84885cd8b2ddc3L28-R37)`)
* Updated the site build step to use `uv run marmite . site --debug` instead of directly running `marmite`. (`[.github/workflows/main.yamlL28-R37](diffhunk://#diff-71cabc4177e41ea8f15a89eb65398fa8187739f68a2762706d84885cd8b2ddc3L28-R37)`)